### PR TITLE
Umstellung auf FOR-Namespace

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -1,4 +1,7 @@
 <?php
+
+use FriendsOfRedaxo\EmailObfuscator\EmailObfuscator;
+
 if (!rex::isBackend()) {
 	rex_extension::register('OUTPUT_FILTER', function ($ep) {
 		$content = $ep->getSubject();
@@ -10,7 +13,7 @@ if (!rex::isBackend()) {
 		$whitelistArticles = preg_grep('/^\s*$/s', explode(",", $emailobfuscator->getConfig('articles', '')), PREG_GREP_INVERT);
 
 		if (!is_null(rex_article::getCurrent()) && !in_array(rex_article::getCurrent()->getTemplateId(), $whitelistTemplates) && !in_array(rex_article::getCurrentId(), $whitelistArticles)) {
-			return emailobfuscator::obfuscate($content);
+			return EmailObfuscator::obfuscate($content);
 		}
 		
 		return $content;

--- a/lib/EmailObfuscator.php
+++ b/lib/EmailObfuscator.php
@@ -1,6 +1,11 @@
 <?php
 
-class emailobfuscator {
+namespace FriendsOfRedaxo\EmailObfuscator;
+
+use rex_addon;
+use rex_config;
+
+class EmailObfuscator {
 	/**
 	 * @var string[] Array with whitelisted email addresses  
 	 */


### PR DESCRIPTION
Vorschlag: Das Addon auf den Namespace `FriendsOfRedaxo\EmailObfuscator` umstellen.

Dann muss man so Sachen nicht auf den letzten Drücker machen wenn REDAXO 6 unmittelbar vor der Tür steht und genügend andere Arbeiten anstehen.

- Datei `class.emailobfuscator.php` umbenannt in `EmailObfuscator.php`
- Klasse `emailobfuscator` geändert in `EmailObfuscator`
- Namespace auf `FriendsOfRedaxo\EmailObfuscator` gesetzt
- Referenzen im Addon angepasst (`boot.php`)
- Keine Anpssung der Versionsnummer in der `package.yml`, kein Vermerk im nicht vorhandenen Changelog
- Da in der Readme keine Hinweise auf die Klasse `emailobfuscator` stehen, musse nichts angepasst werden.

Der PR kollidiert mit #45. Da selbiger eine wesentliche kleinere Änderung vorschlägt, wäre es u.U. arbeitsökonomisch sinnvoll, diesen PR zuerst zu mergen. 